### PR TITLE
Bugfix examples/uint63z/prims.c

### DIFF
--- a/examples/uint63z/prims.c
+++ b/examples/uint63z/prims.c
@@ -34,7 +34,7 @@ value uint63_to_Z(struct thread_info *tinfo, value t) {
   // loop over bits from left (most significant) to right (least significant)
   // ignore the last bit, hence i > 0, not i >= 0
   for (unsigned int i = sizeof(value) * 8 - 1; i > 0; i--) {
-    _Bool bit = ((size_t)t & (1 << i)) >> i;
+    _Bool bit = ((size_t)t & (1ULL << i)) >> i;
     if (bit) {
       if (temp) {
         temp = alloc_make_Coq_Numbers_BinNums_positive_xI(tinfo, temp);


### PR DESCRIPTION
…gfixes)

Here, the sub-expression "(1 << i) is interpreted as shifting a signed integer by the unsigned integer value i, according to the ISO/IEC C standard [11, §6.4.4.1]. But when the size of value is 8 byte, i.e. 64 bits, which is the default case, the expression “unsigned int i = sizeof(value) * 8 - 1” evaluates to “unsigned int i = 63”. Thus, in the first iteration of the loop, the integer value 1 (which has 32 bits) is shifted left by 63 bits which is a shift over- flow. However, no error is provoked when compiling the file with the GCC for user space with the proposed compilation flags. But when adding the compiler flag -fsanitize=shift which adds runtime instrumentation for recognising shift overflows and is used by default for compiling Kernel modules, a runtime error (shift-out-of-bounds) is generated. The solution is here to add the suffix “ULL” to the integer constant 1.

[11]: https://www.open-std.org/jtc1/sc22/wg14/www/docs/n1570.pdf